### PR TITLE
Fix/debian buster aarch64

### DIFF
--- a/base32.c
+++ b/base32.c
@@ -83,7 +83,7 @@ static unsigned char encode_char(unsigned char c)
  */
 static int decode_char(unsigned char c)
 {
-	char retval = -1;
+	signed char retval = -1;
 
 	if (c >= 'A' && c <= 'Z')
 		retval = c - 'A';
@@ -139,7 +139,7 @@ static int get_offset(int block)
  * We need this as bitwise shifting by a negative offset is undefined
  * behavior.
  */
-static unsigned char shift_right(unsigned char byte, char offset)
+static unsigned char shift_right(unsigned char byte, signed char offset)
 {
 	if (offset > 0)
 		return byte >>  offset;
@@ -147,7 +147,7 @@ static unsigned char shift_right(unsigned char byte, char offset)
 		return byte << -offset;
 }
 
-static unsigned char shift_left(unsigned char byte, char offset)
+static unsigned char shift_left(unsigned char byte, signed char offset)
 {
 	return shift_right(byte, - offset);
 }

--- a/base32.c
+++ b/base32.c
@@ -27,54 +27,8 @@
 
 #include "base32.h"
 
-/**
- * Let this be a sequence of plain data before encoding:
- *
- *  01234567 01234567 01234567 01234567 01234567
- * +--------+--------+--------+--------+--------+
- * |< 0 >< 1| >< 2 ><|.3 >< 4.|>< 5 ><.|6 >< 7 >|
- * +--------+--------+--------+--------+--------+
- *
- * There are 5 octets of 8 bits each in each sequence.
- * There are 8 blocks of 5 bits each in each sequence.
- *
- * You probably want to refer to that graph when reading the algorithms in this
- * file. We use "octet" instead of "byte" intentionnaly as we really work with
- * 8 bits quantities. This implementation will probably not work properly on
- * systems that don't have exactly 8 bits per (unsigned) char.
- **/
-
-/*
-static size_t min(size_t x, size_t y)
-{
-	return x < y ? x : y;
-}
-*/
-
 static const unsigned char PADDING_CHAR = '=';
 static const unsigned char base32[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
-
-/**
- * Pad the given buffer with len padding characters.
- */
-/*
-static void pad(unsigned char *buf, int len)
-{
-	for (int i = 0; i < len; i++)
-		buf[i] = PADDING_CHAR;
-}
-*/
-
-/**
- * This convert a 5 bits value into a base32 character.
- * Only the 5 least significant bits are used.
- */
-/*
-static unsigned char encode_char(unsigned char c)
-{
-	return base32[c & 0x1F];  // 0001 1111
-}
-*/
 
 /**
  * Decode given character into a 5 bits value. 
@@ -151,50 +105,6 @@ static unsigned char shift_left(unsigned char byte, signed char offset)
 {
 	return shift_right(byte, - offset);
 }
-
-/**
- * Encode a sequence. A sequence is no longer than 5 octets by definition.
- * Thus passing a length greater than 5 to this function is an error. Encoding
- * sequences shorter than 5 octets is supported and padding will be added to the
- * output as per the specification.
- */
-/*
-static void encode_sequence(const unsigned char *plain, int len, unsigned char *coded)
-{
-	assert(CHAR_BIT == 8);  // not sure this would work otherwise
-	assert(len >= 0 && len <= 5);
-
-	for (int block = 0; block < 8; block++) {
-		int octet = get_octet(block);  // figure out which octet this block starts in
-		int junk = get_offset(block);  // how many bits do we drop from this octet?
-
-		if (octet >= len) { // we hit the end of the buffer
-			pad(&coded[block], 8 - block);
-			return;
-		}
-
-		unsigned char c = shift_right(plain[octet], junk);  // first part
-
-		if (junk < 0  // is there a second part?
-		&&  octet < len - 1)  // is there still something to read?
-		{
-			c |= shift_right(plain[octet+1], 8 + junk);
-		}
-		coded[block] = encode_char(c);
-	}
-}
-*/
-
-/*
-void base32_encode(const unsigned char *plain, size_t len, unsigned char *coded)
-{
-	// All the hard work is done in encode_sequence(),
-	// here we just need to feed it the data sequence by sequence.
-	for (size_t i = 0, j = 0; i < len; i += 5, j += 8) {
-		encode_sequence(&plain[i], min(len - i, 5), &coded[j]);
-	}
-}
-*/
 
 static int decode_sequence(const unsigned char *coded, unsigned char *plain)
 {

--- a/cppcheck
+++ b/cppcheck
@@ -1,5 +1,5 @@
 #!/bin/bash
-export INCL_1=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/13.0.0/include
+export INCL_1=/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/*/include
 export INCL_2=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include
 export JINCL="$JAVA_HOME/include"
 


### PR DESCRIPTION
Fix `char` incorrectly being interpreted as `unsigned char`.